### PR TITLE
Relax jsx-tag-open so ternaries are not mistaken

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -978,7 +978,11 @@ repository:
     match: \S*
 
   jsx-tag-open:
-    begin: (<)([_$a-zA-Z][-$\w.]*(?<!\.|-))(?=\s|/?>)
+    begin: >-
+      (?x)
+        (<)
+        ([_$a-zA-Z][-$\w.]*(?<!\.|-))
+        (?=\s+(?!\?)|/?>)
     end: (/?>)
     name: tag.open.js
     beginCaptures:
@@ -992,7 +996,10 @@ repository:
     - include: '#jsx-tag-attributes-illegal'
 
   jsx-tag-close:
-    begin: (</)([_$a-zA-Z][-$\w.]*(?<!\.|-))
+    begin: >-
+      (?x)
+        (</)
+        ([_$a-zA-Z][-$\w.]*(?<!\.|-))
     end: (>)
     name: tag.close.js
     captures:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -588,7 +588,9 @@
 		<key>jsx-tag-close</key>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;/)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))</string>
+			<string>(?x)
+  (&lt;/)
+  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -629,7 +631,10 @@
 		<key>jsx-tag-open</key>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))(?=\s|/?&gt;)</string>
+			<string>(?x)
+  (&lt;)
+  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
+  (?=\s+(?!\?)|/?&gt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/test/jsx-attributes.jsx
+++ b/test/jsx-attributes.jsx
@@ -12,6 +12,7 @@
 <div className='MyClass' key={1} >
 <div className='MyClass' key={1} />
 <div className = 'MyClass' key={1} />
+<div className = 'MyClass' key={() => this.setState({})} />
 <div class-Name= 'MyClass' key />
 <div className= 'MyClass' key =  '' />
 <div className = 'MyClass'

--- a/test/jsx-tag-name.jsx
+++ b/test/jsx-tag-name.jsx
@@ -3,6 +3,7 @@ var a = b < cat()
 var a = b <cat[1]
 var a = b < cat[1]
 var a = b <cat?
+var a = b <cat ?
 var a = b < cat?
 var a = b <cat===
 var a = b < cat===


### PR DESCRIPTION
Fixes #60. Changes `jsx-tag-open` so it won't match a JSX tag if after the tag name there is a `?` - since ternaries in inequality comparisons are common.

**Before:**
![before](https://cloud.githubusercontent.com/assets/830952/6542971/ae267d62-c4d7-11e4-98ba-e33893005ecb.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/830952/6542972/b2b504ca-c4d7-11e4-85dc-e74368c48fbd.png)
