### PR TITLE
Use "#expression" pattern for jsx-evaluated-code

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1027,7 +1027,7 @@ repository:
     endCaptures:
       '0': {name: punctuation.definition.brace.curly.end.js}
     patterns:
-    - include: '#core'
+    - include: '#expression'
 
   jsx-tag-attributes-illegal:
     name: invalid.illegal.attribute.js

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -457,7 +457,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#core</string>
+					<string>#expression</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Narrower matches for `jsx-evaluated-code`, possible because of https://github.com/babel/babel-sublime/pull/62.