### PR TITLE
Simple arrow functions

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -398,6 +398,17 @@ repository:
       patterns:
       - include: '#function-declaration-parameters'
 
+    # e.g. arg => { }
+    - name: meta.function.arrow.js
+      match: >-
+        (?x)
+          (\basync)?\s*
+          \b([_$a-zA-Z][$\w]*)\s*(=>)
+      captures:
+        '1': {name: storage.type.js}
+        '2': {name: variable.parameter.function.js}
+        '3': {name: storage.type.function.arrow.js}
+
     # e.g. Sound.prototype.play = (args) => { }
     - name: meta.prototype.function.arrow.js
       begin: >-
@@ -421,6 +432,26 @@ repository:
       patterns:
       - include: '#function-declaration-parameters'
 
+    # e.g. Sound.prototype.play = arg => { }
+    - name: meta.prototype.function.arrow.js
+      match: >-
+        (?x)
+          (\b_?[A-Z][$\w]*)?
+          (\.)(prototype)
+          (\.)([_$a-zA-Z][$\w]*)
+          \s*=
+          \s*(async)?
+          \s*\b([_$a-zA-Z][$\w]*)\s*(=>)
+      captures:
+        '1': {name: entity.name.class.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: variable.language.prototype.js}
+        '4': {name: keyword.operator.accessor.js}
+        '5': {name: entity.name.function.js}
+        '6': {name: storage.type.js}
+        '7': {name: variable.parameter.function.js}
+        '8': {name: storage.type.function.arrow.js}
+
     # e.g. Sound.play = (args) => { }
     - name: meta.function.static.arrow.js
       begin: >-
@@ -441,6 +472,23 @@ repository:
       patterns:
       - include: '#function-declaration-parameters'
 
+    # e.g. Sound.play = arg => { }
+    - name: meta.function.static.arrow.js
+      match: >-
+        (?x)
+          (\b_?[A-Z][$\w]*)?
+          (\.)([_$a-zA-Z][$\w]*)
+          \s*=
+          \s*(async)?
+          \s*\b([_$a-zA-Z][$\w]*)\s*(=>)
+      captures:
+        '1': {name: entity.name.class.js}
+        '2': {name: keyword.operator.accessor.js}
+        '3': {name: entity.name.function.js}
+        '4': {name: storage.type.js}
+        '5': {name: variable.parameter.function.js}
+        '6': {name: storage.type.function.arrow.js}
+
   literal-arrow-function-labels:
     patterns:
     # e.g. play: (args) => { }
@@ -460,6 +508,21 @@ repository:
         '1': {name: storage.type.function.arrow.js}
       patterns:
       - include: '#function-declaration-parameters'
+
+    # e.g. play: arg => { }
+    - name: meta.function.json.arrow.js
+      match: >-
+        (?x)
+          \b([_$a-zA-Z][$\w]*)
+          \s*(:)
+          \s*(async)?
+          \s*\b([_$a-zA-Z][$\w]*)\s*(=>)
+      captures:
+        '1': {name: entity.name.function.js}
+        '2': {name: punctuation.separator.key-value.js}
+        '3': {name: storage.type.js}
+        '4': {name: variable.parameter.function.js}
+        '5': {name: storage.type.function.arrow.js}
 
     # e.g. "play": (args) => { }
     - name: meta.function.json.arrow.js
@@ -488,6 +551,31 @@ repository:
         '1': {name: storage.type.function.arrow.js}
       patterns:
       - include: '#function-declaration-parameters'
+
+    # e.g. "play": arg => { }
+    - name: meta.function.json.arrow.js
+      match: >-
+        (?x)
+          (?:
+            ((')((?:[^']|\\')*)('))|
+            ((")((?:[^"]|\\")*)("))
+          )
+          \s*(:)
+          \s*(async)?
+          \s*\b([_$a-zA-Z][$\w]*)\s*(=>)
+      captures:
+        '1': {name: string.quoted.single.js}
+        '2': {name: punctuation.definition.string.begin.js}
+        '3': {name: entity.name.function.js}
+        '4': {name: punctuation.definition.string.end.js}
+        '5': {name: string.quoted.double.js}
+        '6': {name: punctuation.definition.string.begin.js}
+        '7': {name: entity.name.function.js}
+        '8': {name: punctuation.definition.string.end.js}
+        '9': {name: punctuation.separator.key-value.js}
+        '10': {name: storage.type.js}
+        '11': {name: variable.parameter.function.js}
+        '12': {name: storage.type.function.arrow.js}
 
   literal-function-call:
     patterns:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -701,6 +701,32 @@
 					</array>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.arrow.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+  (\basync)?\s*
+  \b([_$a-zA-Z][$\w]*)\s*(=&gt;)</string>
+					<key>name</key>
+					<string>meta.function.arrow.js</string>
+				</dict>
+				<dict>
 					<key>begin</key>
 					<string>(?x)
   (\b_?[A-Z][$\w]*)?
@@ -763,6 +789,61 @@
 					</array>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.class.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.prototype.js</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>7</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.js</string>
+						</dict>
+						<key>8</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.arrow.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+  (\b_?[A-Z][$\w]*)?
+  (\.)(prototype)
+  (\.)([_$a-zA-Z][$\w]*)
+  \s*=
+  \s*(async)?
+  \s*\b([_$a-zA-Z][$\w]*)\s*(=&gt;)</string>
+					<key>name</key>
+					<string>meta.prototype.function.arrow.js</string>
+				</dict>
+				<dict>
 					<key>begin</key>
 					<string>(?x)
   (\b_?[A-Z][$\w]*)?
@@ -812,6 +893,50 @@
 							<string>#function-declaration-parameters</string>
 						</dict>
 					</array>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.class.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.accessor.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.js</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.arrow.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+  (\b_?[A-Z][$\w]*)?
+  (\.)([_$a-zA-Z][$\w]*)
+  \s*=
+  \s*(async)?
+  \s*\b([_$a-zA-Z][$\w]*)\s*(=&gt;)</string>
+					<key>name</key>
+					<string>meta.function.static.arrow.js</string>
 				</dict>
 			</array>
 		</dict>
@@ -863,6 +988,44 @@
 							<string>#function-declaration-parameters</string>
 						</dict>
 					</array>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.key-value.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.js</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.arrow.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+  \b([_$a-zA-Z][$\w]*)
+  \s*(:)
+  \s*(async)?
+  \s*\b([_$a-zA-Z][$\w]*)\s*(=&gt;)</string>
+					<key>name</key>
+					<string>meta.function.json.arrow.js</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -946,6 +1109,82 @@
 							<string>#function-declaration-parameters</string>
 						</dict>
 					</array>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.single.js</string>
+						</dict>
+						<key>10</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.js</string>
+						</dict>
+						<key>11</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.js</string>
+						</dict>
+						<key>12</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.function.arrow.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.begin.js</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.end.js</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.double.js</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.begin.js</string>
+						</dict>
+						<key>7</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.js</string>
+						</dict>
+						<key>8</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.end.js</string>
+						</dict>
+						<key>9</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.key-value.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+  (?:
+    ((')((?:[^']|\\')*)('))|
+    ((")((?:[^"]|\\")*)("))
+  )
+  \s*(:)
+  \s*(async)?
+  \s*\b([_$a-zA-Z][$\w]*)\s*(=&gt;)</string>
+					<key>name</key>
+					<string>meta.function.json.arrow.js</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Adds support for single argument w/ no parenthesis arrow functions. This will have to be reverted when it gets merged upstream, and resynced back down.

![dbd921c8-cfff-11e4-9915-c9336d81ecc3](https://cloud.githubusercontent.com/assets/830952/6804877/7b151180-d216-11e4-9443-7e9bba2fbdac.png)
