### PR TITLE
Add "JSON (Babel)"

### DIFF
--- a/JSON (Babel).YAML-tmLanguage
+++ b/JSON (Babel).YAML-tmLanguage
@@ -1,0 +1,151 @@
+# [PackageDev] target_format: plist, ext: tmLanguage
+name: JSON (Babel)
+scopeName: source.json
+fileTypes: [json, sublime-settings, sublime-menu, sublime-keymap, sublime-mousemap,
+  sublime-theme, sublime-build, sublime-project, sublime-completions]
+uuid: 68e2a375-bdf1-4fd4-bbe4-481849a7a5ae
+foldingStartMarker: >-
+  (?x)       # turn on extended mode
+    ^        # a line beginning with
+    \s*      # some optional space
+    [{\[]    # the start of an object or array
+    (?!      # but not followed by
+      .*     # whatever
+      [}\]]  # and the close of an object or array
+      ,?     # an optional comma
+      \s*    # some optional space
+      $      # at the end of the line
+    )
+    |        # ...or...
+    [{\[]    # the start of an object or array
+    \s*      # some optional space
+    $        # at the end of the line
+foldingStopMarker: >-
+  (?x)     # turn on extended mode
+    ^      # a line beginning with
+    \s*    # some optional space
+    [}\]]  # and the close of an object or array
+keyEquivalent: ^~J
+
+patterns:
+- include: '#value'
+
+repository:
+  array:
+    name: meta.structure.array.json
+    begin: \[
+    beginCaptures:
+      '0': {name: punctuation.definition.array.begin.json}
+    end: \]
+    endCaptures:
+      '0': {name: punctuation.definition.array.end.json}
+    patterns:
+    - include: '#value'
+    - name: punctuation.separator.array.json
+      match: ','
+    - name: invalid.illegal.expected-array-separator.json
+      match: '[^\s\]]'
+
+  comments:
+    patterns:
+    - name: comment.block.documentation.json
+      begin: /\*\*
+      end: \*/
+      captures:
+        '0': {name: punctuation.definition.comment.json}
+    - name: comment.block.json
+      begin: /\*
+      end: \*/
+      captures:
+        '0': {name: punctuation.definition.comment.json}
+    - name: comment.line.double-slash.js
+      match: (//).*$\n?
+      captures:
+        '1': {name: punctuation.definition.comment.json}
+
+  constant:
+    name: constant.language.json
+    match: \b(?:true|false|null)\b
+
+  # handles integer and decimal numbers
+  number:
+    name: constant.numeric.json
+    match: >-
+      (?x)        # turn on extended mode
+        -?        # an optional minus
+        (?:
+          0       # a zero
+          |       # ...or...
+          [1-9]   # a 1-9 character
+          \d*     # followed by zero or more digits
+        )
+        (?:
+          (?:
+            \.    # a period
+            \d+   # followed by one or more digits
+          )?
+          (?:
+            [eE]  # an e character
+            [+-]? # followed by an option +/-
+            \d+   # followed by one or more digits
+          )?      # make exponent optional
+        )?        # make decimal portion optional
+
+  # a JSON object
+  object:
+    name: meta.structure.dictionary.json
+    begin: \{
+    beginCaptures:
+      '0': {name: punctuation.definition.dictionary.begin.json}
+    end: \}
+    endCaptures:
+      '0': {name: punctuation.definition.dictionary.end.json}
+    patterns:
+    - comment: the JSON object key
+      include: '#string'
+    - include: '#comments'
+    - name: meta.structure.dictionary.value.json
+      begin: ':'
+      beginCaptures:
+        '0': {name: punctuation.separator.dictionary.key-value.json}
+      end: (,)|(?=\})
+      endCaptures:
+        '1': {name: punctuation.separator.dictionary.pair.json}
+      patterns:
+      - comment: the JSON object value
+        include: '#value'
+      - name: invalid.illegal.expected-dictionary-separator.json
+        match: '[^\s,]'
+    - name: invalid.illegal.expected-dictionary-separator.json
+      match: '[^\s\}]'
+
+  string:
+    name: string.quoted.double.json
+    begin: '"'
+    beginCaptures:
+      '0': {name: punctuation.definition.string.begin.json}
+    end: '"'
+    endCaptures:
+      '0': {name: punctuation.definition.string.end.json}
+    patterns:
+    - name: constant.character.escape.json
+      match: >-
+        (?x)                # turn on extended mode
+          \\                # a literal backslash
+          (?:               # ...followed by...
+            ["\\/bfnrt]     # one of these characters
+            |               # ...or...
+            u               # a u
+            [0-9a-fA-F]{4}) # and four hex digits
+    - name: invalid.illegal.unrecognized-string-escape.json
+      match: \\.
+
+  # the 'value' diagram at http://json.org
+  value:
+    patterns:
+    - include: '#constant'
+    - include: '#number'
+    - include: '#string'
+    - include: '#array'
+    - include: '#object'
+    - include: '#comments'

--- a/JSON (Babel).tmLanguage
+++ b/JSON (Babel).tmLanguage
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>json</string>
+		<string>sublime-settings</string>
+		<string>sublime-menu</string>
+		<string>sublime-keymap</string>
+		<string>sublime-mousemap</string>
+		<string>sublime-theme</string>
+		<string>sublime-build</string>
+		<string>sublime-project</string>
+		<string>sublime-completions</string>
+	</array>
+	<key>foldingStartMarker</key>
+	<string>(?x)       # turn on extended mode
+  ^        # a line beginning with
+  \s*      # some optional space
+  [{\[]    # the start of an object or array
+  (?!      # but not followed by
+    .*     # whatever
+    [}\]]  # and the close of an object or array
+    ,?     # an optional comma
+    \s*    # some optional space
+    $      # at the end of the line
+  )
+  |        # ...or...
+  [{\[]    # the start of an object or array
+  \s*      # some optional space
+  $        # at the end of the line</string>
+	<key>foldingStopMarker</key>
+	<string>(?x)     # turn on extended mode
+  ^      # a line beginning with
+  \s*    # some optional space
+  [}\]]  # and the close of an object or array</string>
+	<key>keyEquivalent</key>
+	<string>^~J</string>
+	<key>name</key>
+	<string>JSON (Babel)</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>#value</string>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>array</key>
+		<dict>
+			<key>begin</key>
+			<string>\[</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.array.begin.json</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\]</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.array.end.json</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.structure.array.json</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#value</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>,</string>
+					<key>name</key>
+					<string>punctuation.separator.array.json</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>[^\s\]]</string>
+					<key>name</key>
+					<string>invalid.illegal.expected-array-separator.json</string>
+				</dict>
+			</array>
+		</dict>
+		<key>comments</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>/\*\*</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.json</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\*/</string>
+					<key>name</key>
+					<string>comment.block.documentation.json</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>/\*</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.json</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\*/</string>
+					<key>name</key>
+					<string>comment.block.json</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.json</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(//).*$\n?</string>
+					<key>name</key>
+					<string>comment.line.double-slash.js</string>
+				</dict>
+			</array>
+		</dict>
+		<key>constant</key>
+		<dict>
+			<key>match</key>
+			<string>\b(?:true|false|null)\b</string>
+			<key>name</key>
+			<string>constant.language.json</string>
+		</dict>
+		<key>number</key>
+		<dict>
+			<key>match</key>
+			<string>(?x)        # turn on extended mode
+  -?        # an optional minus
+  (?:
+    0       # a zero
+    |       # ...or...
+    [1-9]   # a 1-9 character
+    \d*     # followed by zero or more digits
+  )
+  (?:
+    (?:
+      \.    # a period
+      \d+   # followed by one or more digits
+    )?
+    (?:
+      [eE]  # an e character
+      [+-]? # followed by an option +/-
+      \d+   # followed by one or more digits
+    )?      # make exponent optional
+  )?        # make decimal portion optional</string>
+			<key>name</key>
+			<string>constant.numeric.json</string>
+		</dict>
+		<key>object</key>
+		<dict>
+			<key>begin</key>
+			<string>\{</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.dictionary.begin.json</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\}</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.dictionary.end.json</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.structure.dictionary.json</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>the JSON object key</string>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>:</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.dictionary.key-value.json</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(,)|(?=\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.dictionary.pair.json</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.structure.dictionary.value.json</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>comment</key>
+							<string>the JSON object value</string>
+							<key>include</key>
+							<string>#value</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>[^\s,]</string>
+							<key>name</key>
+							<string>invalid.illegal.expected-dictionary-separator.json</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>[^\s\}]</string>
+					<key>name</key>
+					<string>invalid.illegal.expected-dictionary-separator.json</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string</key>
+		<dict>
+			<key>begin</key>
+			<string>"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.json</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>"</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.json</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.quoted.double.json</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?x)                # turn on extended mode
+  \\                # a literal backslash
+  (?:               # ...followed by...
+    ["\\/bfnrt]     # one of these characters
+    |               # ...or...
+    u               # a u
+    [0-9a-fA-F]{4}) # and four hex digits</string>
+					<key>name</key>
+					<string>constant.character.escape.json</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unrecognized-string-escape.json</string>
+				</dict>
+			</array>
+		</dict>
+		<key>value</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#constant</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#number</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#array</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#object</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>scopeName</key>
+	<string>source.json</string>
+	<key>uuid</key>
+	<string>68e2a375-bdf1-4fd4-bbe4-481849a7a5ae</string>
+</dict>
+</plist>

--- a/JavaScript Indent.YAML-tmPreferences
+++ b/JavaScript Indent.YAML-tmPreferences
@@ -1,0 +1,11 @@
+# [PackageDev] target_format: plist, ext: tmPreferences
+name: JavaScript Indent
+uuid: 8a0c166b-cb02-42ca-8eeb-8df963c80a37
+scope: source.js
+settings:
+  bracketIndentNextLinePattern: >-
+    (?x)
+      ^ \s* \b(if|while|else)\b [^;]* $
+      | ^ \s* \b(for)\b .* $
+  decreaseIndentPattern: ^(.*\*/)?\s*[}].*$
+  increaseIndentPattern: ^.*\{[^}"']*$

--- a/JavaScript Indent.tmPreferences
+++ b/JavaScript Indent.tmPreferences
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>JavaScript Indent</string>
+	<key>scope</key>
+	<string>source.js</string>
+	<key>settings</key>
+	<dict>
+		<key>bracketIndentNextLinePattern</key>
+		<string>(?x)
+  ^ \s* \b(if|while|else)\b [^;]* $
+  | ^ \s* \b(for)\b .* $</string>
+		<key>decreaseIndentPattern</key>
+		<string>^(.*\*/)?\s*[}].*$</string>
+		<key>increaseIndentPattern</key>
+		<string>^.*\{[^}"']*$</string>
+	</dict>
+	<key>uuid</key>
+	<string>8a0c166b-cb02-42ca-8eeb-8df963c80a37</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ To set it as the default syntax for a particular extension:
 
 `Babel` comes bundled with `Next` and `Monokai` from [Benvie/JavaScriptNext.tmLanguage](https://github.com/Benvie/JavaScriptNext.tmLanguage). Select one from `Preferences` `->` `Color Scheme` `->` `Babel`
 
+#### Advanced usage
+
+It possible to set `Babel` as the _only_ JavaScript package by disabling the stock one. To do so, add `"ignored_packages": ["JavaScript"]` to your `Preferences.sublime-settings`. The benefits include:
+  * extension-less node scripts will automatically be recognized as `JavaScript (Babel)`,
+  * and reduced clutter in the syntax menu.
+
+**Keep in mind**, the stock snippets will no longer work (you may still use your own), and other third-party packages that depend on the stock package may break (no known ones so far).
+
 ## Screenshots
 
 ![babel-sublime-vs-sublime-react--react-class](https://raw.githubusercontent.com/babel/babel-sublime/45c7d37/screenshots/compare-react-class@2x.png)


### PR DESCRIPTION
This is the stock sublime JSON syntax. The point of including this is so that you can disable the stock JavaScript package - but still have JSON support. The benefits of doing this are:

  * node scripts without an extension that have a shebang will open as "JavaScript (Babel)" instead of with the stock JavaScript. The reason this wouldn't work otherwise is because Sublime will prioritize the stock package's `firstLineMatch: ^#!\s*/.*\b(node|js)$\n?` over babel-sublime. By disabling the stock package, babel-sublime wins out.
  * No more junky stock snippets.
  * Less clutter in the syntax menu.

Add this to your `Preferences.sublime-settings` if you want this behavior :smile: 

```json
	"ignored_packages": ["JavaScript"]
```

cc: @sebmck (1) I have to write docs for this, (2) I have to figure out if disabling the stock package brakes any other packages - it doesn't break embedded html scripts, and (3) This kinda opens the door for having legit modern babel-sublime snippets since they won't clash with the stock ones.