### PR TITLE
Include string-content in literal-quasi

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -900,6 +900,7 @@ repository:
       endCaptures:
         '0': {name: punctuation.definition.quasi.end.js}
       patterns:
+      - include: '#string-content'
       - name: entity.quasi.element.js
         begin: \${
         beginCaptures:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -2389,6 +2389,10 @@
 					<key>patterns</key>
 					<array>
 						<dict>
+							<key>include</key>
+							<string>#string-content</string>
+						</dict>
+						<dict>
 							<key>begin</key>
 							<string>\${</string>
 							<key>beginCaptures</key>


### PR DESCRIPTION
This will have to be reverted when it gets merged upstream, and resynced back down.

![before](https://cloud.githubusercontent.com/assets/830952/7059762/32b13c0e-de44-11e4-9e66-64649736bb3e.png)
![after](https://cloud.githubusercontent.com/assets/830952/7059775/49b2edc6-de44-11e4-9e58-fa34a6a45d87.png)

