### PR TITLE
Add jsx text in children support

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -24,7 +24,6 @@ repository:
 
   expression:
     patterns:
-    # jsx
     - include: '#jsx'
     - include: '#es7-decorators'
 
@@ -1159,9 +1158,9 @@ repository:
     match: =(?=\s*(?:'|"|{|/\*|//|\n))
 
   jsx-string-double-quoted:
+    name: string.quoted.double.js
     begin: '"'
     end: '"'
-    name: string.quoted.double.js
     beginCaptures:
       '0': {name: punctuation.definition.string.begin.js}
     endCaptures:
@@ -1170,9 +1169,9 @@ repository:
     - include: '#jsx-entities'
 
   jsx-string-single-quoted:
+    name: string.quoted.single.js
     begin: "'"
     end: "'"
-    name: string.quoted.single.js
     beginCaptures:
       '0': {name: punctuation.definition.string.begin.js}
     endCaptures:
@@ -1191,9 +1190,9 @@ repository:
       match: '&'
 
   jsx-evaluated-code:
+    name: meta.brace.curly.js
     begin: '{'
     end: '}'
-    name: meta.brace.curly.js
     beginCaptures:
       '0': {name: punctuation.definition.brace.curly.start.js}
     endCaptures:
@@ -1205,14 +1204,29 @@ repository:
     name: invalid.illegal.attribute.js
     match: \S*
 
+  jsx-tag-without-attributes:
+    name: tag.without-attributes.js
+    begin: (<)([_$a-zA-Z][-$\w.]*(?<!\.|-))(>)
+    end: (</)([_$a-zA-Z][-$\w.]*(?<!\.|-))(>)
+    beginCaptures:
+      '1': {name: punctuation.definition.tag.begin.js}
+      '2': {name: entity.name.tag.js}
+      '3': {name: punctuation.definition.tag.end.js}
+    endCaptures:
+      '1': {name: punctuation.definition.tag.begin.js}
+      '2': {name: entity.name.tag.js}
+      '3': {name: punctuation.definition.tag.end.js}
+    patterns:
+    - include: '#jsx-children'
+
   jsx-tag-open:
+    name: tag.open.js
     begin: >-
       (?x)
         (<)
         ([_$a-zA-Z][-$\w.]*(?<!\.|-))
         (?=\s+(?!\?)|/?>)
     end: (/?>)
-    name: tag.open.js
     beginCaptures:
       '1': {name: punctuation.definition.tag.begin.js}
       '2': {name: entity.name.tag.js}
@@ -1224,12 +1238,9 @@ repository:
     - include: '#jsx-tag-attributes-illegal'
 
   jsx-tag-close:
-    begin: >-
-      (?x)
-        (</)
-        ([_$a-zA-Z][-$\w.]*(?<!\.|-))
-    end: (>)
     name: tag.close.js
+    begin: (</)([_$a-zA-Z][-$\w.]*(?<!\.|-))
+    end: (>)
     beginCaptures:
       '1': {name: punctuation.definition.tag.begin.js}
       '2': {name: entity.name.tag.js}
@@ -1242,12 +1253,28 @@ repository:
     name: invalid.illegal.tag.incomplete.js
     match: <\s*>
 
-  jsx:
-    name: meta.jsx.js
+  jsx-children:
     patterns:
+    - include: '#jsx-tag-without-attributes'
     - include: '#jsx-tag-open'
     - include: '#jsx-tag-close'
     - include: '#jsx-tag-invalid'
+    - include: '#jsx-evaluated-code'
+    - include: '#jsx-entities'
+
+  jsx:
+    name: meta.jsx.js
+    patterns:
+    - include: '#jsx-tag-without-attributes'
+    - include: '#jsx-tag-open'
+    - include: '#jsx-tag-close'
+    - include: '#jsx-tag-invalid'
+
+    - name: meta.jsx.children.js
+      begin: (?<=(?:'|"|})>)
+      end: (?=</)
+      patterns:
+      - include: '#jsx-children'
 
   # stage 0 proposal: https://gist.github.com/jeffmo/054df782c05639da2adb
   es7-class-properties:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -433,6 +433,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#jsx-tag-without-attributes</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#jsx-tag-open</string>
 				</dict>
 				<dict>
@@ -442,6 +446,51 @@
 				<dict>
 					<key>include</key>
 					<string>#jsx-tag-invalid</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?&lt;=(?:'|"|})&gt;)</string>
+					<key>end</key>
+					<string>(?=&lt;/)</string>
+					<key>name</key>
+					<string>meta.jsx.children.js</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#jsx-children</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>jsx-children</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-without-attributes</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-open</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-close</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-invalid</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-evaluated-code</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-entities</string>
 				</dict>
 			</array>
 		</dict>
@@ -633,9 +682,7 @@
 		<key>jsx-tag-close</key>
 		<dict>
 			<key>begin</key>
-			<string>(?x)
-  (&lt;/)
-  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))</string>
+			<string>(&lt;/)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -721,6 +768,58 @@
 				<dict>
 					<key>include</key>
 					<string>#jsx-tag-attributes-illegal</string>
+				</dict>
+			</array>
+		</dict>
+		<key>jsx-tag-without-attributes</key>
+		<dict>
+			<key>begin</key>
+			<string>(&lt;)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))(&gt;)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.js</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.js</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.js</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(&lt;/)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))(&gt;)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.js</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.js</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.js</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>tag.without-attributes.js</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#jsx-children</string>
 				</dict>
 			</array>
 		</dict>

--- a/test/jsx-text.js
+++ b/test/jsx-text.js
@@ -1,0 +1,69 @@
+/**
+ * These have always work
+ */
+<div>
+  {'it\'s with text inside'}
+</div>
+
+<div>{'it\'s with text inside'}</div>
+
+<div
+  attr=''>
+  {'it\'s with text inside'}
+</div>
+
+<div attr="">{'it\'s with text inside'}</div>
+<div
+  attr="">
+  {"it's with text inside"}
+</div>
+
+<div attr={}>{"it's with text inside"}</div>
+<div
+  attr={}>
+  {"it's with text inside"}
+</div>
+
+
+/**
+ * Fixed
+ */
+<div>
+  it's with text inside
+</div>
+
+<div>it's with text inside</div>
+
+<div
+  attr=''>
+  it's with text inside
+</div>
+
+<div attr="">it's with text inside</div>
+<div
+  attr="">
+  it's with text inside
+</div>
+
+<div attr={}>it's with text inside</div>
+<div
+  attr={}>
+  it's with text inside
+</div>
+
+/**
+ * Don't work
+ */
+
+<div attr>it's with text inside</div>
+
+/**/
+
+<div
+  >it's with text inside</div>
+
+/**/
+
+<div
+  attr={}
+  >it's with text inside</div>


### PR DESCRIPTION
It doesn't work in two cases: When the `>` in the opening tag is on it's own line, or when the last attribute doesn't have a value. I can't match those to cases because it creates a lot of false positives with greater-than comparisons.

![compare](https://cloud.githubusercontent.com/assets/830952/7215797/c90dc5c0-e5b3-11e4-858b-98868a918494.png)

This branch still needs work. I have to clean up the scopes and test it some more.