### PR TITLE
Workaround JSX-like Type Parameters in JavaScript (Babel)

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1206,7 +1206,7 @@ repository:
 
   jsx-tag-without-attributes:
     name: tag.without-attributes.js
-    begin: (<)([_$a-zA-Z][-$\w.]*(?<!\.|-))(>)
+    begin: (?<!\w)(<)([_$a-zA-Z][-$\w.]*(?<!\.|-))(>)
     end: (</)([_$a-zA-Z][-$\w.]*(?<!\.|-))(>)
     beginCaptures:
       '1': {name: punctuation.definition.tag.begin.js}
@@ -1223,6 +1223,7 @@ repository:
     name: tag.open.js
     begin: >-
       (?x)
+        (?<!\w)
         (<)
         ([_$a-zA-Z][-$\w.]*(?<!\.|-))
         (?=\s+(?!\?)|/?>)

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -727,6 +727,7 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)
+  (?&lt;!\w)
   (&lt;)
   ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
   (?=\s+(?!\?)|/?&gt;)</string>
@@ -774,7 +775,7 @@
 		<key>jsx-tag-without-attributes</key>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))(&gt;)</string>
+			<string>(?&lt;!\w)(&lt;)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))(&gt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/test/jsx-text.js
+++ b/test/jsx-text.js
@@ -67,3 +67,7 @@
 <div
   attr={}
   >it's with text inside</div>
+
+/**/
+
+Array<Function>it's with text inside</Function>


### PR DESCRIPTION
JavaScript type systems like TypeScript and Flow allow type parameters that **JavaScript (Babel)** think are JSX:

```
var callbacks: Array<Function>;
```

This works around the issue (without having to implement full fledge support for either TypeScript or Flow) by checking whether there's a word character preceding the open angle bracket. (Yes, `Array <Function>` is technically a legal type annotation, but don't do that.)