### PR TITLE
Added WeakSet and Emmet Support for JSX

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1,6 +1,6 @@
 # [PackageDev] target_format: plist, ext: tmLanguage
 name: JavaScript (Babel)
-scopeName: source.js
+scopeName: source.js.jsx
 fileTypes: [js, htc, jsx]
 uuid: 30c49d33-6e4d-4985-8a18-34431c2535c6
 firstLineMatch: ^#!\s*/.*\b(node|js)$\n?
@@ -1067,7 +1067,7 @@ repository:
     patterns:
     # built-ins
     - name: support.class.builtin.js
-      match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap)\b
+      match: \b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap|WeakSet)\b
 
     - name: support.function.js
       match: (?<!\.)\b(decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval|isFinite|isNaN|parseFloat|parseInt|unescape)\b

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -3201,7 +3201,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap)\b</string>
+					<string>\b(Array|Boolean|Date|Function|Map|Math|Number|Object|Promise|Proxy|RegExp|Set|String|WeakMap|WeakSet)\b</string>
 					<key>name</key>
 					<string>support.class.builtin.js</string>
 				</dict>
@@ -3364,7 +3364,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.js</string>
+	<string>source.js.jsx</string>
 	<key>uuid</key>
 	<string>30c49d33-6e4d-4985-8a18-34431c2535c6</string>
 </dict>


### PR DESCRIPTION
@zertosh Emmet's default is to not support JS files and i end up defining a keybinding provided by <a href='https://github.com/allanhortle'>Allan Hortle</a> in his <a href='https://github.com/allanhortle/JSX'>JSX</a> package. I also find the scope defined in the .tmLanguage so i added source.js.jsx there and removed keybinding. It works the same.