### PR TITLE
Fix "no such context" message

### DIFF
--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -935,7 +935,7 @@ contexts:
             - match: "}"
               scope: punctuation.definition.string.interpolated.element.end.js
               pop: true
-            - include: expressions
+            - include: expression
 
   string-content:
     - match: \\\s*\n


### PR DESCRIPTION
Been getting the following warning / error / message:

```
no such context expressions at line 938 column 24 in Packages/Babel/JavaScript (Babel).sublime-syntax
```