### PR TITLE
template string "${" and "}" as keyword

### DIFF
--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -931,10 +931,10 @@ contexts:
       pop: true
     - include: string-content
     - match: '\${'
-      scope: punctuation.definition.string.interpolated.element.begin.js
+      scope: keyword.operator.substitution.js
       set:
         - match: "}"
-          scope: punctuation.definition.string.interpolated.element.end.js
+          scope: keyword.operator.substitution.js
           set: literal-template-string-inner
         - include: expression
 


### PR DESCRIPTION
The [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-template-literal-lexical-components) doesn't call these anything. But since there is precedent with `keyword.generator.asterisk.js` and `keyword.operator.spread.js`, I'm going to call these `keyword.operator.substitution.js`. Why? Mostly so that themes color them. Compare the screenshots in #168. My personal theme had a special rule for these punctuations, but it makes sense for everyone.