### PR TITLE
jsx fixes

### DIFF
--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -1117,9 +1117,6 @@ contexts:
       push:
         - meta_include_prototype: false
         - meta_scope: string.quoted.js
-        - match: '\n'
-          scope: invalid.illegal.newline.js
-          pop: true
         - match: '\1'
           scope: punctuation.definition.string.quoted.end.js
           pop: true

--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -1075,11 +1075,11 @@ contexts:
             \Wreturn  |
             ^return   |
             ^
-          )\s*(?=<[_$a-zA-Z][-$\w.]*)
+          )\s*(?=<[_$a-zA-Z][-$:.\w]*[$\w]*)
       push: jsx-element
 
   jsx-element:
-    - match: (<)([_$a-zA-Z][-$\w.]*)
+    - match: (<)([_$a-zA-Z][-$:.\w]*[$\w]*)
       captures:
         1: punctuation.definition.tag.begin.js
         2: entity.name.tag.js
@@ -1093,9 +1093,9 @@ contexts:
         - match: '>'
           scope: punctuation.definition.tag.end.js
           set:
-            - match: (?=<[_$a-zA-Z][-$\w.]*)
+            - match: (?=<[_$a-zA-Z][-$:.\w]*[$\w]*)
               push: jsx-element
-            - match: (</)([_$a-zA-Z][-$\w.]*)(>)
+            - match: (</)([_$a-zA-Z][-$:.\w]*[$\w]*)(>)
               scope: tag.close.js
               captures:
                 1: punctuation.definition.tag.end.js

--- a/samples/jsx-es6.jsx
+++ b/samples/jsx-es6.jsx
@@ -25,6 +25,7 @@ export default React.createClass({
     var list = this.props.secondary.map(pic => <img src={pic} />)}
     return (
       <div {...this.props} overlay={<div>test</div>}>
+        <ns:tag></ns:tag>
         {list}
         {[<span>in an array</span>]}
         <input /*cmt*/

--- a/samples/jsx-es6.jsx
+++ b/samples/jsx-es6.jsx
@@ -23,6 +23,8 @@ export default React.createClass({
   render() {
     var {email} = this.state;
     var list = this.props.secondary.map(pic => <img src={pic} />)}
+    var multilineAttr = <a desc="ab
+      cdef"></a>
     return (
       <div {...this.props} overlay={<div>test</div>}>
         <ns:tag></ns:tag>


### PR DESCRIPTION
It turns out that string attributes can be [multiline](http://babeljs.io/repl/#?experimental=true&evaluate=true&loose=false&spec=false&code=%3Ctag%0A%20%20desc%3D%22a%0A%20%20b%22%20%2F%3E%0A).

It also turns out that we use namespaced (with a `:`) elements at fb, but that's not a thing in JSX. So sorry everyone for adding it.