### PR TITLE
Capture merge conflicts...

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -22,6 +22,7 @@ repository:
 
   expression:
     patterns:
+    - include: '#merge-conflits'
     - include: '#literal-regexp'              # before operators and keywords to avoid ambiguities
 
     - include: '#literal-jsx'
@@ -1092,3 +1093,17 @@ repository:
       captures:
         '1': {name: punctuation.definition.tag.js}
         '2': {name: entity.name.tag.js}
+
+  merge-conflits:
+    patterns:
+    - match: ^([<]{7}) (.+)$
+      captures:
+        '1': {name: invalid.illegal.conflict-marker.merge-into.js}
+        '2': {name: invalid.illegal.string.js}
+    - match: ^([=|]{7})$
+      captures:
+        '1': {name: invalid.illegal.conflict-marker.separator.js}
+    - match: ^([>]{7}) (.+)$
+      captures:
+        '1': {name: invalid.illegal.conflict-marker.other-commit.js}
+        '2': {name: invalid.illegal.string.js}

--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -26,6 +26,7 @@ contexts:
     - include: literal-punctuation
 
   expression:
+    - include: merge-conflits
     - include: literal-regexp
     - include: literal-jsx
     - include: es7-decorators
@@ -1067,3 +1068,16 @@ contexts:
       captures:
         1: punctuation.definition.tag.js
         2: entity.name.tag.js
+
+  merge-conflits:
+    - match: ^([<]{7}) (.+)$
+      captures:
+        1: invalid.illegal.conflict-marker.merge-into.js
+        2: invalid.illegal.string.js
+    - match: ^([=|]{7})$
+      captures:
+        1: invalid.illegal.conflict-marker.separator.js
+    - match: ^([>]{7}) (.+)$
+      captures:
+        1: invalid.illegal.conflict-marker.other-commit.js
+        2: invalid.illegal.string.js

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -230,6 +230,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#merge-conflits</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#literal-regexp</string>
 				</dict>
 				<dict>
@@ -2595,6 +2599,58 @@
 					<string>[_$a-zA-Z][$\w]*</string>
 					<key>name</key>
 					<string>variable.other.readwrite.js</string>
+				</dict>
+			</array>
+		</dict>
+		<key>merge-conflits</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.illegal.conflict-marker.merge-into.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.illegal.string.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^([&lt;]{7}) (.+)$</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.illegal.conflict-marker.separator.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^([=|]{7})$</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.illegal.conflict-marker.other-commit.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.illegal.string.js</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>^([&gt;]{7}) (.+)$</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Because they get confused as JSX as disrupt all the highlighting - making resolving conflicts really annoying.

![upkuf](https://cloud.githubusercontent.com/assets/830952/10409522/047cafdc-6ed9-11e5-8405-1662dc226e18.png)
