### PR TITLE
Add DocBlockr support

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -100,6 +100,12 @@ repository:
 
   comments:
     patterns:
+    - name: comment.block.documentation.js
+      begin: /\*\*(?!/)
+      captures:
+        '0': {name: punctuation.definition.comment.js}
+      end: \*/
+
     - name: comment.block.js
       begin: /\*
       beginCaptures:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -369,6 +369,22 @@
 			<array>
 				<dict>
 					<key>begin</key>
+					<string>/\*\*(?!/)</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.comment.js</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\*/</string>
+					<key>name</key>
+					<string>comment.block.documentation.js</string>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>/\*</string>
 					<key>beginCaptures</key>
 					<dict>


### PR DESCRIPTION
  - DocBlockr uses ["comment.block.documentation.js"](https://github.com/spadgos/sublime-jsdocs/blob/master/js.sublime-completions) from the default JavaScript.tmLanguage
  - Adds this pattern back to `comments`

Using JavaScript (Babel) as the primary language breaks DocBlockr's ability to autocomplete when typing `@` within JSDoc style comments (`/** foo */`).