### PR TITLE
Fix incorrect syntax highlighting for `type`

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -205,7 +205,11 @@ repository:
       match: (?<!\.)\b(declare)\b
 
     - name: meta.type.flowtype.js
-      begin: (?<!\.)\b(type)\b(?=\s*[_$a-zA-Z])
+      # this is pretty convoluted, but we want to explicitly avoid matching type
+      # in `type of x` (may appear in ES6 foreach), `type in x` and
+      # `type instanceof x`. (e.g. avoid matching any typical JS alphabetical
+      # binary operators)
+      begin: (?<!\.)\b(type)\b(?=\s*(?:[_$a-hj-np-zA-Z]|o[^f]|of\B|i[^n]|in[^s\W]|ins[^t]|inst[^a]|insta[^n]|instan[^c]|instanc[^e]|instance[^o]|instanceo[^f]|instanceof\B))
       beginCaptures:
         '1': {name: support.type.type.flowtype.js}
       end: (?=\s*(;|from))

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -741,7 +741,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(?&lt;!\.)\b(type)\b(?=\s*[_$a-zA-Z])</string>
+					<string>(?&lt;!\.)\b(type)\b(?=\s*(?:[_$a-hj-np-zA-Z]|o[^f]|of\B|i[^n]|in[^s\W]|ins[^t]|inst[^a]|insta[^n]|instan[^c]|instanc[^e]|instance[^o]|instanceo[^f]|instanceof\B))</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Fixes #221.

I don't use flow, but I think it shouldn't break the existing highlighting for flow type declarations, since it just explicitly excludes `of`, `in`, and `instanceof`. 

Note that there may be a cleaner way to do this (using a negative lookahead _inside_ the positive lookahead?) but I couldn't get any of the things I tried to work.
