### PR TITLE
Add acme color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Sublime Text Color Schemes which are ready for JavaScript's new features and bab
 
 [![zeus-color-scheme](https://raw.githubusercontent.com/zaynali53/Zeus-Theme/master/Zeus-Color-Scheme.PNG)](https://github.com/zaynali53/Zeus-Theme)
 
+#### [Acme Color Scheme](https://github.com/zaynali53/acme-color-scheme)
+<a href="https://github.com/zaynali53/acme-color-scheme">
+  <img width="728" src="https://raw.githubusercontent.com/zaynali53/acme-color-scheme/master/img/babel-preview.png">
+</a>
+
 ## About
 
 Under the hood, _babel-sublime_ is based on the excellent [Benvie/JavaScriptNext.tmLanguage](https://github.com/Benvie/JavaScriptNext.tmLanguage) with JSX syntax support built on top. The initial definitions for JSX came from [reactjs/sublime-react](https://github.com/reactjs/sublime-react) via [yungters/sublime](https://github.com/yungsters/sublime.git) - special thanks go to [@jgebhardt](https://github.com/jgebhardt) and [@zpao](https://github.com/zpao).


### PR DESCRIPTION
Adds `Acme Color Scheme` to the suggested resources

Package Control: [Acme Color Scheme](https://packagecontrol.io/packages/Acme%20Color%20Scheme)

<img width="728" src="https://raw.githubusercontent.com/zaynali53/acme-color-scheme/master/img/babel-preview.png">
