### PR TITLE
Fix bug: ES6 modules: wrong scope for "default" keyword

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -33,10 +33,10 @@ repository:
     - include: '#literal-arrow-function'
     - include: '#literal-prototype'           # after literal-function, which includes some prototype strings
 
+    - include: '#literal-module'              # before literal-keywords, so "default" isn't matched as keyword.control.loop
     - include: '#literal-keywords'
 
     - include: '#literal-method'
-    - include: '#literal-module'
     - include: '#literal-class'
     - include: '#flowtype-declaration'
 

--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -37,10 +37,10 @@ contexts:
     - include: literal-arrow-function
     - include: literal-prototype          # after literal-function, which includes some prototype strings
 
+    - include: literal-module             # before literal-keywords, so "default" isn't matched as keyword.control.loop
     - include: literal-keywords
 
     - include: literal-method
-    - include: literal-module
     - include: literal-class
     - include: flowtype-declaration
 

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -590,15 +590,15 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#literal-module</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#literal-keywords</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>#literal-method</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#literal-module</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
For example:

```
export default MyClass
       ^^^^^^^
       source.js keyword.control.loop.js
```

Should be:

```
export default MyClass
       ^^^^^^^
       source.js keyword.operator.module.js
```

See [MDN](https://developer.mozilla.org/en/docs/web/javascript/reference/statements/export#Using_the_default_export).
