### PR TITLE
Fix bug: wrong scope for function return Flow type annotation

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -423,10 +423,12 @@ repository:
         '4': {name: storage.type.function.js}
         '5': {name: keyword.generator.asterisk.js}
         '6': {name: entity.name.function.js}
-      end: (?<=\))
+      end: (?=\s*[;{])
       patterns:
       - include: '#flowtype-polymorph'
       - include: '#function-declaration-parameters'
+      - include: '#flowtype-annotation'
+      - include: '#curly-brackets'
 
     # e.g. Sound.prototype.play = function(arg1, arg2) {  }
     - name: meta.function.prototype.js
@@ -450,10 +452,12 @@ repository:
         '8': {name: storage.type.function.js}
         '9': {name: keyword.generator.asterisk.js}
         '10': {name: entity.name.function.js}
-      end: (?<=\))
+      end: (?=\s*[;{])
       patterns:
       - include: '#flowtype-polymorph'
       - include: '#function-declaration-parameters'
+      - include: '#flowtype-annotation'
+      - include: '#curly-brackets'
 
     # e.g. Sound.play = function(arg1, arg2) {  }
     - name: meta.function.static.js
@@ -474,10 +478,12 @@ repository:
         '6': {name: storage.type.function.js}
         '7': {name: keyword.generator.asterisk.js}
         '8': {name: entity.name.function.js}
-      end: (?<=\))
+      end: (?=\s*[;{])
       patterns:
       - include: '#flowtype-polymorph'
       - include: '#function-declaration-parameters'
+      - include: '#flowtype-annotation'
+      - include: '#curly-brackets'
 
   literal-function-labels:
     patterns:

--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -424,10 +424,12 @@ contexts:
         6: entity.name.function.js
       push:
         - meta_scope: meta.function.js
-        - match: (?<=\))
+        - match: (?=\s*[;{])
           pop: true
         - include: flowtype-polymorph
         - include: function-declaration-parameters
+        - include: flowtype-annotation
+        - include: curly-brackets
 
     # e.g. Sound.prototype.play = function(arg1, arg2) {  }
     - match: >-
@@ -452,10 +454,12 @@ contexts:
         10: entity.name.function.js
       push:
         - meta_scope: meta.function.prototype.js
-        - match: (?<=\))
+        - match: (?=\s*[;{])
           pop: true
         - include: flowtype-polymorph
         - include: function-declaration-parameters
+        - include: flowtype-annotation
+        - include: curly-brackets
 
     # e.g. Sound.play = function(arg1, arg2) {  }
     - match: >-
@@ -477,10 +481,12 @@ contexts:
         8: entity.name.function.js
       push:
         - meta_scope: meta.function.static.js
-        - match: (?<=\))
+        - match: (?=\s*[;{])
           pop: true
         - include: flowtype-polymorph
         - include: function-declaration-parameters
+        - include: flowtype-annotation
+        - include: curly-brackets
 
   literal-function-labels:
     # e.g. play: function(arg1, arg2) {  }

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -2124,7 +2124,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?&lt;=\))</string>
+					<string>(?=\s*[;{])</string>
 					<key>name</key>
 					<string>meta.function.js</string>
 					<key>patterns</key>
@@ -2136,6 +2136,14 @@
 						<dict>
 							<key>include</key>
 							<string>#function-declaration-parameters</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#flowtype-annotation</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#curly-brackets</string>
 						</dict>
 					</array>
 				</dict>
@@ -2203,7 +2211,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?&lt;=\))</string>
+					<string>(?=\s*[;{])</string>
 					<key>name</key>
 					<string>meta.function.prototype.js</string>
 					<key>patterns</key>
@@ -2215,6 +2223,14 @@
 						<dict>
 							<key>include</key>
 							<string>#function-declaration-parameters</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#flowtype-annotation</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#curly-brackets</string>
 						</dict>
 					</array>
 				</dict>
@@ -2271,7 +2287,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?&lt;=\))</string>
+					<string>(?=\s*[;{])</string>
 					<key>name</key>
 					<string>meta.function.static.js</string>
 					<key>patterns</key>
@@ -2283,6 +2299,14 @@
 						<dict>
 							<key>include</key>
 							<string>#function-declaration-parameters</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#flowtype-annotation</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#curly-brackets</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
See [flowtype.org/docs/syntax.html#function-declarations](https://flowtype.org/docs/syntax.html#function-declarations).

For example:

```
function play():                   boolean { return true; }
Sound.prototype.play = function(): boolean { return true; };
Sound.play = function():           boolean { return true; };
                                   ^^^^^^^
                                   source.js
                                   variable.other.readwrite.js
```

Should be:

```
function play():                   boolean { return true; }
Sound.prototype.play = function(): boolean { return true; };
Sound.play = function():           boolean { return true; };
                                   ^^^^^^^
                                   source.js
                                   ...
                                   meta.flowtype.annotation.js
                                   constant.other.primitve.flowtype.js
```

I copied the syntax from [`class-method-definition`](https://github.com/babel/babel-sublime/blob/v8.6.3/JavaScript%20%28Babel%29.sublime-syntax#L239-L244), and it seems to work, but please let me know if any additional changes are needed. Thanks!
