### PR TITLE
Removes empty captures

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1215,7 +1215,7 @@ repository:
         '3': {name: support.type.object.process.js}
         '4': {name: support.function.process.js}
 
-    - match: (?<!\.)\b(exports|module(?:(\.)(children|exports|filename|id|loaded|parent)))?\b
+    - match: (?<!\.)\b(exports|module)(?:(\.)(children|exports|filename|id|loaded|parent))?\b
       captures:
         '1': {name: support.type.object.module.js}
         '2': {name: keyword.operator.accessor.js}

--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -905,12 +905,12 @@ repository:
         (?x)
           !(?!=)| # logical-not     right-to-left   right
           &&    | # logical-and     left-to-right   both
-          \|\|  | # logical-or      left-to-right   both
+          \|\|    # logical-or      left-to-right   both
 
     - name: keyword.operator.assignment.js
       match: >-
         (?x)
-          =(?!=)| # assignment      right-to-left   both
+          =(?!=)  # assignment      right-to-left   both
 
     - name: keyword.operator.assignment.augmented.js
       match: >-
@@ -925,7 +925,7 @@ repository:
           \|=  | # assignment      right-to-left   both
           <<=  | # assignment      right-to-left   both
           >>=  | # assignment      right-to-left   both
-          >>>= | # assignment      right-to-left   both
+          >>>=   # assignment      right-to-left   both
 
     - name: keyword.operator.bitwise.js
       match: >-


### PR DESCRIPTION
These rules are causing issues with both first-mate and vscode-textmate, because they match empty strings and can cause infinite loops. The trailing | are unnecessary and are not present in the other rules, so I just had to remove them altogether.