### PR TITLE
Support GraphQL syntax

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1160,22 +1160,22 @@ repository:
       end: '`'
       patterns:
       - include: source.graphql
-      - name: source.js
+      - name: js
         begin: '\${'
         end: '}'
         patterns:
-        - include: source.js
+        - include: '#core'
 
     - name: meta.graphql.js
       begin: '\s*+`#graphql'
       end: '`'
       patterns:
       - include: source.graphql
-      - name: source.js
+      - name: js
         begin: '\${'
         end: '}'
         patterns:
-        - include: source.js
+        - include: '#core'
 
 
   literal-variable:

--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1160,12 +1160,22 @@ repository:
       end: '`'
       patterns:
       - include: source.graphql
+      - name: source.js
+        begin: '\${'
+        end: '}'
+        patterns:
+        - include: source.js
 
     - name: meta.graphql.js
       begin: '\s*+`#graphql'
       end: '`'
       patterns:
       - include: source.graphql
+      - name: source.js
+        begin: '\${'
+        end: '}'
+        patterns:
+        - include: source.js
 
 
   literal-variable:

--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1161,6 +1161,13 @@ repository:
       patterns:
       - include: source.graphql
 
+    - name: meta.graphql.js
+      begin: '\s*+`#graphql'
+      end: '`'
+      patterns:
+      - include: source.graphql
+
+
   literal-variable:
     patterns:
     # e.g. CONSTANT

--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -18,6 +18,7 @@ repository:
     - include: '#literal-switch'
 
     - include: '#styled-components'           # add support for styled-components
+    - include: '#graphql'
 
     - include: '#expression'
     - include: '#literal-punctuation'
@@ -1151,6 +1152,14 @@ repository:
           '0': {name: punctuation.definition.string.template.end.js}
         patterns:
         - include: source.js.css
+
+  graphql:
+    patterns:
+    - name: meta.graphql.js
+      begin: '\s*+gql`'
+      end: '`'
+      patterns:
+      - include: source.graphql
 
   literal-variable:
     patterns:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -1135,6 +1135,21 @@
 							<key>include</key>
 							<string>source.graphql</string>
 						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\${</string>
+							<key>end</key>
+							<string>}</string>
+							<key>name</key>
+							<string>source.js</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.js</string>
+								</dict>
+							</array>
+						</dict>
 					</array>
 				</dict>
 				<dict>
@@ -1149,6 +1164,21 @@
 						<dict>
 							<key>include</key>
 							<string>source.graphql</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\${</string>
+							<key>end</key>
+							<string>}</string>
+							<key>name</key>
+							<string>source.js</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.js</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -481,6 +481,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#graphql</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#expression</string>
 				</dict>
 				<dict>
@@ -1109,6 +1113,27 @@
 									<string>#expression</string>
 								</dict>
 							</array>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>graphql</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\s*+gql`</string>
+					<key>end</key>
+					<string>`</string>
+					<key>name</key>
+					<string>meta.graphql.js</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.graphql</string>
 						</dict>
 					</array>
 				</dict>
@@ -2990,14 +3015,14 @@
 					<string>(?x)
   !(?!=)| # logical-not     right-to-left   right
   &amp;&amp;    | # logical-and     left-to-right   both
-  \|\|  | # logical-or      left-to-right   both</string>
+  \|\|    # logical-or      left-to-right   both</string>
 					<key>name</key>
 					<string>keyword.operator.logical.js</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>(?x)
-  =(?!=)| # assignment      right-to-left   both</string>
+  =(?!=)  # assignment      right-to-left   both</string>
 					<key>name</key>
 					<string>keyword.operator.assignment.js</string>
 				</dict>
@@ -3014,7 +3039,7 @@
   \|=  | # assignment      right-to-left   both
   &lt;&lt;=  | # assignment      right-to-left   both
   &gt;&gt;=  | # assignment      right-to-left   both
-  &gt;&gt;&gt;= | # assignment      right-to-left   both</string>
+  &gt;&gt;&gt;=   # assignment      right-to-left   both</string>
 					<key>name</key>
 					<string>keyword.operator.assignment.augmented.js</string>
 				</dict>
@@ -3914,7 +3939,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(exports|module(?:(\.)(children|exports|filename|id|loaded|parent)))?\b</string>
+					<string>(?&lt;!\.)\b(exports|module)(?:(\.)(children|exports|filename|id|loaded|parent))?\b</string>
 				</dict>
 				<dict>
 					<key>begin</key>

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -1141,12 +1141,12 @@
 							<key>end</key>
 							<string>}</string>
 							<key>name</key>
-							<string>source.js</string>
+							<string>js</string>
 							<key>patterns</key>
 							<array>
 								<dict>
 									<key>include</key>
-									<string>source.js</string>
+									<string>#core</string>
 								</dict>
 							</array>
 						</dict>
@@ -1171,12 +1171,12 @@
 							<key>end</key>
 							<string>}</string>
 							<key>name</key>
-							<string>source.js</string>
+							<string>js</string>
 							<key>patterns</key>
 							<array>
 								<dict>
 									<key>include</key>
-									<string>source.js</string>
+									<string>#core</string>
 								</dict>
 							</array>
 						</dict>

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -1137,6 +1137,21 @@
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\s*+`#graphql</string>
+					<key>end</key>
+					<string>`</string>
+					<key>name</key>
+					<string>meta.graphql.js</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.graphql</string>
+						</dict>
+					</array>
+				</dict>
 			</array>
 		</dict>
 		<key>jsx-attribute-assignment</key>


### PR DESCRIPTION
Enables syntax highlighting in javascript files if a GraphQL language definition package like [GraphQL](https://github.com/dncrews/GraphQL-SublimeText3) is installed.

Highlights when called with `gql`:
![image](https://user-images.githubusercontent.com/1495211/31775472-011dc314-b4e9-11e7-8c1c-49c1af2571af.png)


or with a `#graphql` comment:
![image](https://user-images.githubusercontent.com/1495211/31775320-8d256da4-b4e8-11e7-9246-d7119ab030fc.png)