### PR TITLE
Added spaces to multiline comments

### DIFF
--- a/Comments.YAML-tmPreferences
+++ b/Comments.YAML-tmPreferences
@@ -6,6 +6,6 @@ settings:
   - name: TM_COMMENT_START
     value: '// '
   - name: TM_COMMENT_START_2
-    value: /*
+    value: '/* '
   - name: TM_COMMENT_END_2
-    value: '*/'
+    value: ' */'

--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -20,13 +20,13 @@
 				<key>name</key>
 				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
-				<string>/*</string>
+				<string>/* </string>
 			</dict>
 			<dict>
 				<key>name</key>
 				<string>TM_COMMENT_END_2</string>
 				<key>value</key>
-				<string>*/</string>
+				<string> */</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
It's generally considered good taste to space comment text from comment delimiters:

```js
/* something here */
```
Rather than:

```js
/*something here*/
```

This PR fixes it.