### PR TITLE
Add support for tagged html template strings

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -27,6 +27,7 @@ repository:
     - include: '#merge-conflits'
     - include: '#literal-regexp'              # before operators and keywords to avoid ambiguities
     - include: '#literal-jsx'
+    - include: '#literal-tagged-html'
     - include: '#es7-decorators'
     - include: '#support-class'
     - include: '#support-other'
@@ -1310,6 +1311,19 @@ repository:
       match: '&(?:[a-zA-Z0-9]+|#\d+|#x\h+);'
     - name: invalid.illegal.bad-ampersand.jsx
       match: '&\S*;'
+
+  literal-tagged-html:
+    patterns:
+    - contentName: text.html.basic.embedded.js
+      begin: '(html)(`)'
+      beginCaptures:
+        '1': {name: meta.function-call.tagged-template.js}
+        '2': {name: punctuation.definition.string.template.begin.js}
+      end: '`'
+      endCaptures:
+        '0': {name: punctuation.definition.string.template.end.js}
+      patterns:
+      - include: 'text.html.basic'
 
   # https://github.com/wycats/javascript-decorators
   es7-decorators:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -570,6 +570,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#literal-tagged-html</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#es7-decorators</string>
 				</dict>
 				<dict>
@@ -2990,14 +2994,14 @@
 					<string>(?x)
   !(?!=)| # logical-not     right-to-left   right
   &amp;&amp;    | # logical-and     left-to-right   both
-  \|\|  | # logical-or      left-to-right   both</string>
+  \|\|    # logical-or      left-to-right   both</string>
 					<key>name</key>
 					<string>keyword.operator.logical.js</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>(?x)
-  =(?!=)| # assignment      right-to-left   both</string>
+  =(?!=)  # assignment      right-to-left   both</string>
 					<key>name</key>
 					<string>keyword.operator.assignment.js</string>
 				</dict>
@@ -3014,7 +3018,7 @@
   \|=  | # assignment      right-to-left   both
   &lt;&lt;=  | # assignment      right-to-left   both
   &gt;&gt;=  | # assignment      right-to-left   both
-  &gt;&gt;&gt;= | # assignment      right-to-left   both</string>
+  &gt;&gt;&gt;=   # assignment      right-to-left   both</string>
 					<key>name</key>
 					<string>keyword.operator.assignment.augmented.js</string>
 				</dict>
@@ -3330,6 +3334,48 @@
 									<string>$self</string>
 								</dict>
 							</array>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>literal-tagged-html</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(html)(`)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>meta.function-call.tagged-template.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.template.begin.js</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>text.html.basic.embedded.js</string>
+					<key>end</key>
+					<string>`</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.template.end.js</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>text.html.basic</string>
 						</dict>
 					</array>
 				</dict>
@@ -3914,7 +3960,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(exports|module(?:(\.)(children|exports|filename|id|loaded|parent)))?\b</string>
+					<string>(?&lt;!\.)\b(exports|module)(?:(\.)(children|exports|filename|id|loaded|parent))?\b</string>
 				</dict>
 				<dict>
 					<key>begin</key>


### PR DESCRIPTION
Fixes #138 

<img width="741" alt="screenshot 2018-02-15 02 58 34" src="https://user-images.githubusercontent.com/145218/36237593-f4c661ae-11fc-11e8-93ec-a3e9b944e90f.png">

Adds support for HTML highlighting inside template literals tagged with an `html` function. Support for this feature has been implemented in Babel highlighting for Atom for a while, and even GitHub highlights it like it's supposed to (thanks @DylanPiercey for pointing that out in https://github.com/babel/babel-sublime/issues/138#issuecomment-282814040):

```js
const it = html`
  <div>hi</div>
`
```

It's also a fairly important part of [Polymer](https://www.polymer-project.org/) starting from 2.4. As the Polymer documentation puts it:

> Some text editors support HTML code highlighting in JavaScript template literals tagged with a function called html.

Let's expand the list of "some text editors" :)