### PR TITLE
Support JSX fragments

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1258,14 +1258,14 @@ repository:
 
   literal-jsx:
     contentName: meta.jsx.js
-    begin: (?<=\(|\{|\[|,|&&|\|\||\?|:|=|=>|\Wreturn|^return|\Wdefault|^)(?=\s*<[_$a-zA-Z])
+    begin: (?<=\(|\{|\[|,|&&|\|\||\?|:|=|=>|\Wreturn|^return|\Wdefault|^)(?=\s*<[_$>a-zA-Z])
     end: (?<=/>|>)
     patterns:
     - include: '#jsx-tag-start'
 
   jsx-tag-start:
     patterns:
-    - begin: (<)([_$a-zA-Z][-$:.\w]*[$\w]*)
+    - begin: (<)([_$a-zA-Z][-$:.\w]*[$\w]*)?
       beginCaptures:
         '1': {name: meta.tag.jsx punctuation.definition.tag.begin.jsx}
         '2': {name: meta.tag.jsx entity.name.tag.jsx}

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -1342,7 +1342,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(&lt;)([_$a-zA-Z][-$:.\w]*[$\w]*)</string>
+					<string>(&lt;)([_$a-zA-Z][-$:.\w]*[$\w]*)?</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -2530,7 +2530,7 @@
 		<key>literal-jsx</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;=\(|\{|\[|,|&amp;&amp;|\|\||\?|:|=|=&gt;|\Wreturn|^return|\Wdefault|^)(?=\s*&lt;[_$a-zA-Z])</string>
+			<string>(?&lt;=\(|\{|\[|,|&amp;&amp;|\|\||\?|:|=|=&gt;|\Wreturn|^return|\Wdefault|^)(?=\s*&lt;[_$&gt;a-zA-Z])</string>
 			<key>contentName</key>
 			<string>meta.jsx.js</string>
 			<key>end</key>


### PR DESCRIPTION
This is just an extension of #351 from @gaearon adding the same two changes to file "JavaScript (Babel).tmLanguage". Tries to solve issues #348 and #368.
This worked for me locally, I hope someone can add tests or missing requirements to merge.
