### PR TITLE
Add support files from core JavaScript package.

### DIFF
--- a/support/Comments.tmPreferences
+++ b/support/Comments.tmPreferences
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.js, source.json</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/support/Completion Rules.tmPreferences
+++ b/support/Completion Rules.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.js</string>
+	<key>settings</key>
+	<dict>
+		<key>cancelCompletion</key>
+		<string>^\s*(\{?\s*(else|return|do)|(function)\s*[a-zA-Z_0-9]+)$</string>
+	</dict>
+</dict>
+</plist>

--- a/support/Indexed Symbols.tmPreferences
+++ b/support/Indexed Symbols.tmPreferences
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.js meta.function.declaration.js entity.name.function.js, source.js meta.class.js entity.name.class.js</string>
+	<key>settings</key>
+	<dict>
+		<key>showInIndexedSymbolList</key>
+		<string>1</string>
+	</dict>
+</dict>
+</plist>

--- a/support/JavaScript Indent.tmPreferences
+++ b/support/JavaScript Indent.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>JavaScript Indent</string>
+	<key>scope</key>
+	<string>source.js</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^(.*\*/)?\s*\}.*$</string>
+		<key>increaseIndentPattern</key>
+		<string>^.*\{[^}"']*$</string>
+
+		<key>bracketIndentNextLinePattern</key>
+		<string>(?x)
+		^ \s* \b(if|while|else)\b [^;]* $
+		| ^ \s* \b(for)\b .* $
+		</string>
+	</dict>
+</dict>
+</plist>

--- a/support/Regular Expressions (JavaScript).sublime-syntax
+++ b/support/Regular Expressions (JavaScript).sublime-syntax
@@ -1,0 +1,131 @@
+%YAML 1.2
+---
+name: Regular Expressions (Javascript)
+scope: source.regexp.js
+hidden: true
+variables:
+  identifier: '[_$[:alpha:]][_$[:alnum:]]*'
+contexts:
+  main:
+    - include: anchor
+    - include: backref
+    - include: quantifier
+    - include: operator
+    - include: group-assertion
+    - include: group-definition
+    - include: character-class
+    - include: character-class-definition
+
+  anchor:
+    - match: '\\[bB]|\^|\$'
+      scope: keyword.control.anchor.regexp
+
+  backref:
+    - match: '\\[1-9][0-9]*'
+      scope: keyword.other.back-reference.regexp
+
+    - match: (\\k)(<)({{identifier}})(>)
+      captures:
+        1: keyword.other.back-reference.regexp
+        2: punctuation.definition.group.named.begin.regexp
+        3: variable.other.group.regexp
+        4: punctuation.definition.group.named.end.regexp
+
+  character-class:
+    - match: '\\[wWsSdD]|\.'
+      scope: constant.other.character-class.escape.backslash.regexp
+    - match: '(\\[pP])(\{)([[:alpha:]_]+)(?:(=)([[:alpha:]_]+)?)?(\})'
+      captures:
+        1: constant.other.character-class.escape.unicode-property.regexp
+        2: punctuation.definition.unicode-property.begin.regexp
+        3: support.constant.unicode-property.regexp
+        4: punctuation.separator.key-value.unicode-property.regexp
+        5: support.constant.unicode-property.regexp
+        6: punctuation.definition.unicode-property.end.regexp
+    - match: '\\([trnvf0\\]|c[A-Z]|x[\da-fA-F]{2}|u[\da-fA-F]{4}|.)'
+      scope: constant.character.escape.backslash.regexp
+
+  character-class-definition:
+    - match: '(\[)(\^)?'
+      captures:
+        1: punctuation.definition.character-class.begin.regexp
+        2: keyword.operator.negation.regexp
+      push:
+        - meta_scope: constant.other.character-class.set.regexp
+        - match: '\]'
+          scope: punctuation.definition.character-class.end.regexp
+          pop: true
+        - match: |-
+            (?x)
+            (?:
+              (\\[wWsSdD]|\.)|
+              (\\(?:[trnvf0]|c[A-Z]|x[\da-fA-F]{2}|u[\da-fA-F]{4}|.))|
+              .
+            )
+            (\-)
+            (?:
+              (\\[wWsSdD]|\.)|
+              (\\(?:[trnvf0]|c[A-Z]|x[\da-fA-F]{2}|u[\da-fA-F]{4}|.))|
+              [^]]
+            )
+          scope: constant.other.character-class.range.regexp
+          captures:
+            1: constant.other.character-class.escape.backslash.regexp
+            2: constant.character.escape.backslash.regexp
+            3: punctuation.definition.range.regexp
+            4: constant.other.character-class.escape.backslash.regexp
+            5: constant.character.escape.backslash.regexp
+        - include: character-class
+
+  group-assertion:
+    - match: (\()((\?=)|(\?!)|(\?<=)|(\?<!))
+      captures:
+        1: punctuation.definition.group.begin.regexp
+        2: punctuation.definition.group.assertion.regexp
+        3: meta.assertion.look-ahead.regexp
+        4: meta.assertion.negative-look-ahead.regexp
+        5: meta.assertion.look-behind.regexp
+        6: meta.assertion.negative-look-behind.regexp
+      push:
+        - meta_scope: meta.group.assertion.regexp
+        - match: \)
+          scope: punctuation.definition.group.end.regexp
+          pop: true
+        - include: main
+
+  group-definition:
+    - match: (\()(?:(\?:)|(\?)(<)({{identifier}})(>))?
+      captures:
+        1: punctuation.definition.group.begin.regexp
+        2: punctuation.definition.group.no-capture.regexp
+        3: punctuation.definition.group.begin.regexp
+        4: punctuation.definition.group.named.begin.regexp
+        5: entity.name.other.group.regexp
+        6: punctuation.definition.group.named.end.regexp
+      push:
+        - meta_scope: meta.group.regexp
+        - match: \)
+          scope: punctuation.definition.group.end.regexp
+          pop: true
+        - include: main
+
+  operator:
+    - match: \|
+      scope: keyword.operator.or.regexp
+
+  quantifier:
+    - match: '[?*+]\??'
+      scope: keyword.operator.quantifier.regexp
+
+    - match: '\{(\d+)(?:(,)(\d+)?)?\}'
+      scope: keyword.operator.quantifier.regexp
+      captures:
+        1: constant.literal.numeric.regexp
+        2: punctuation.separator.comma.regexp
+        3: constant.literal.numeric.regexp
+
+    - match: \{(,)(\d+)\}
+      scope: keyword.operator.quantifier.regexp
+      captures:
+        1: punctuation.separator.comma.regexp
+        2: constant.literal.numeric.regexp

--- a/support/Symbol List Banned.tmPreferences
+++ b/support/Symbol List Banned.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List Banned</string>
+	<key>scope</key>
+	<string>source.js meta.function.anonymous</string>
+	<key>settings</key>
+	<dict>
+		<key>showInIndexedSymbolList</key>
+		<string>0</string>
+		<key>showInSymbolList</key>
+		<string>0</string>
+	</dict>
+</dict>
+</plist>

--- a/support/Symbol List Function.tmPreferences
+++ b/support/Symbol List Function.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List Function</string>
+	<key>scope</key>
+	<string>source.js meta.function.declaration, source.js entity.name.class</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>s/\s+/ /g;</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
The readme used to suggest disabling the core JavaScript package. This should cause problems, because this package didn't provide any of the commenting, symbol, or indentation rules that the core package does. This PR straight-up copies those files from the core syntax (as of build 3189) so that everything will work even if the JavaScript package is disabled.