### PR TITLE
Improve JSX attribute comments.

### DIFF
--- a/JSX (Inner).YAML-tmPreferences
+++ b/JSX (Inner).YAML-tmPreferences
@@ -1,6 +1,6 @@
 # [PackageDev] target_format: plist, ext: tmPreferences
 name: JSX
-scope: source.js meta.jsx.js - meta.embedded.expression
+scope: source.js meta.jsx.js - meta.embedded.expression - meta.tag.name - meta.tag.attributes
 settings:
   shellVariables:
   - name: TM_COMMENT_START

--- a/JSX (Inner).tmPreferences
+++ b/JSX (Inner).tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>JSX</string>
 	<key>scope</key>
-	<string>source.js meta.jsx.js - meta.embedded.expression</string>
+	<string>source.js meta.jsx.js - meta.embedded.expression - meta.tag.name - meta.tag.attributes</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>

--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -83,7 +83,7 @@ contexts:
     - include: else-pop
 
   jsx-tag-attributes:
-    - meta_content_scope: meta.tag.js
+    - meta_content_scope: meta.tag.attributes.js
 
     - match: '>'
       scope: punctuation.definition.tag.end.js


### PR DESCRIPTION
A minor tweak to JSX parsing and the comment rules to make commenting attributes work better.

Note: this is done by directly editing the compiled syntax definition, which is absolutely not a reasonable thing to do and I should go to workflow jail. However, I'm doing it anyway because:

- This is definitely annoying real people right now.
- There's already [an upstream PR](https://github.com/sublimehq/Packages/pull/2787/files) that does the same thing.
- There probably won't be any more changes to the syntax in v10 anyway; the next version will most likely be for ST4 and include the proper fix anyway.