### PR TITLE
Patch ASI lookahead to fix block comment bug.

### DIFF
--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -2882,7 +2882,6 @@ variables:
     )
   line_continuation_lookahead: >-
     (?x:(?=
-      \s*
       (?! \+\+ | -- )
       (?=
         != |


### PR DESCRIPTION
This fix is already in core, so v11 will not need to replicate this patch.