### PR TITLE
Fix #427

### DIFF
--- a/JavaScript (Babel).sublime-syntax
+++ b/JavaScript (Babel).sublime-syntax
@@ -1798,7 +1798,7 @@ contexts:
                 - include: immediately-pop
             -   - meta_include_prototype: false
                 - match: ''
-                  set: scope:source.js.css#at-keyframe-block-content
+                  set: scope:source.js.css:at-keyframe-block-content
                   with_prototype:
                     - match: (?=`)
                       pop: true


### PR DESCRIPTION
idk  if this is "correct", but `\`${` still highlights correctly, so
![image](https://user-images.githubusercontent.com/6709544/236220509-86d9d693-804c-42f4-9f33-536d0dd367f7.png)
